### PR TITLE
Add support for (un)install hooks

### DIFF
--- a/main.go
+++ b/main.go
@@ -283,6 +283,12 @@ func checkJSON(c *cli.Context) error {
 		return cli.NewExitError(err.Error(), 1)
 	}
 
+	for _, hook := range wixFile.Hooks {
+		if _, ok := manifest.PossibleWhenValues[hook.When]; !ok {
+			return cli.NewExitError(`Invalid "when" value in hook: `+hook.When, 1)
+		}
+	}
+
 	fmt.Println("The manifest is syntaxically correct !")
 
 	if wixFile.NeedGUID() {

--- a/templates/product.wxs
+++ b/templates/product.wxs
@@ -16,7 +16,7 @@
             Manufacturer="{{.Company}}"
             Language="1033">
 
-      <Package InstallerVersion="200" Compressed="yes" Comments="Windows Installer Package"/>
+      <Package InstallerVersion="200" Compressed="yes" Comments="Windows Installer Package" InstallScope="perMachine"/>
 
       <Media Id="1" Cabinet="product.cab" EmbedCab="yes"/>
 
@@ -92,14 +92,13 @@
       </Directory>
 
       {{range $i, $e := .Hooks}}
-      <CustomAction Id="SetArgsCustomExec{{$i}}" Property="WixQuietExecCmdLine" Value="{{$e.CookedCommand}}"/>
-      <CustomAction Id="CustomExec{{$i}}" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="immediate" Return="check"/>
+      <SetProperty Id="CustomExec{{$i}}" Value="{{$e.CookedCommand}}" Before="CustomExec{{$i}}" Sequence="execute"/>
+      <CustomAction Id="CustomExec{{$i}}" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="check" Impersonate="no"/>
       {{end}}
       <InstallExecuteSequence>
          <RemoveExistingProducts After="InstallValidate"/>
          {{range $i, $e := .Hooks}}
-         <Custom Action="SetArgsCustomExec{{$i}}" After="{{if eq $i 0}}InstallFinalize{{else}}CustomExec{{dec $i}}{{end}}">{{if eq $e.When "install"}}NOT Installed AND NOT REMOVE{{else}}REMOVE ~= "ALL"{{end}}</Custom>
-         <Custom Action="CustomExec{{$i}}" After="SetArgsCustomExec{{$i}}">{{if eq $e.When "install"}}NOT Installed AND NOT REMOVE{{else}}REMOVE ~= "ALL"{{end}}</Custom>
+         <Custom Action="CustomExec{{$i}}" After="{{if eq $i 0}}InstallFiles{{else}}CustomExec{{dec $i}}{{end}}">{{if eq $e.When "install"}}NOT Installed AND NOT REMOVE{{else}}REMOVE ~= "ALL"{{end}}</Custom>
          {{end}}
       </InstallExecuteSequence>
 

--- a/templates/product.wxs
+++ b/templates/product.wxs
@@ -91,14 +91,21 @@
 
       </Directory>
 
-      {{range $i, $e := .Hooks}}
-      <SetProperty Id="CustomExec{{$i}}" Value="{{$e.CookedCommand}}" Before="CustomExec{{$i}}" Sequence="execute"/>
-      <CustomAction Id="CustomExec{{$i}}" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="check" Impersonate="no"/>
+      {{range $i, $e := .InstallHooks}}
+      <SetProperty Id="CustomInstallExec{{$i}}" Value="{{$e.CookedCommand}}" Before="CustomInstallExec{{$i}}" Sequence="execute"/>
+      <CustomAction Id="CustomInstallExec{{$i}}" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="check" Impersonate="no"/>
+      {{end}}
+      {{range $i, $e := .UninstallHooks}}
+      <SetProperty Id="CustomUninstallExec{{$i}}" Value="{{$e.CookedCommand}}" Before="CustomUninstallExec{{$i}}" Sequence="execute"/>
+      <CustomAction Id="CustomUninstallExec{{$i}}" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="check" Impersonate="no"/>
       {{end}}
       <InstallExecuteSequence>
          <RemoveExistingProducts After="InstallValidate"/>
-         {{range $i, $e := .Hooks}}
-         <Custom Action="CustomExec{{$i}}" After="{{if eq $i 0}}InstallFiles{{else}}CustomExec{{dec $i}}{{end}}">{{if eq $e.When "install"}}NOT Installed AND NOT REMOVE{{else}}REMOVE ~= "ALL"{{end}}</Custom>
+         {{range $i, $e := .InstallHooks}}
+         <Custom Action="CustomInstallExec{{$i}}" After="{{if eq $i 0}}InstallFiles{{else}}CustomInstallExec{{dec $i}}{{end}}">NOT Installed AND NOT REMOVE</Custom>
+         {{end}}
+         {{range $i, $e := .InstallHooks}}
+         <Custom Action="CustomUninstallExec{{$i}}" After="{{if eq $i 0}}InstallInitialize{{else}}CustomUninstallExec{{dec $i}}{{end}}">REMOVE ~= "ALL"</Custom>
          {{end}}
       </InstallExecuteSequence>
 

--- a/templates/product.wxs
+++ b/templates/product.wxs
@@ -91,8 +91,16 @@
 
       </Directory>
 
+      {{range $i, $e := .Hooks}}
+      <CustomAction Id="SetArgsCustomExec{{$i}}" Property="WixQuietExecCmdLine" Value="{{$e.CookedCommand}}"/>
+      <CustomAction Id="CustomExec{{$i}}" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="immediate" Return="check"/>
+      {{end}}
       <InstallExecuteSequence>
          <RemoveExistingProducts After="InstallValidate"/>
+         {{range $i, $e := .Hooks}}
+         <Custom Action="SetArgsCustomExec{{$i}}" After="{{if eq $i 0}}InstallFinalize{{else}}CustomExec{{dec $i}}{{end}}">{{if eq $e.When "install"}}NOT Installed AND NOT REMOVE{{else}}REMOVE ~= "ALL"{{end}}</Custom>
+         <Custom Action="CustomExec{{$i}}" After="SetArgsCustomExec{{$i}}">{{if eq $e.When "install"}}NOT Installed AND NOT REMOVE{{else}}REMOVE ~= "ALL"{{end}}</Custom>
+         {{end}}
       </InstallExecuteSequence>
 
       <Feature Id="DefaultFeature" Level="1">

--- a/tpls/index.go
+++ b/tpls/index.go
@@ -9,6 +9,12 @@ import (
 	"github.com/mh-cbon/go-msi/manifest"
 )
 
+var funcMap = template.FuncMap{
+	"dec": func(i int) int {
+		return i - 1
+	},
+}
+
 // Find all wxs fies in given directory
 func Find(srcDir string, pattern string) ([]string, error) {
 	glob := filepath.Join(srcDir, pattern)
@@ -17,7 +23,7 @@ func Find(srcDir string, pattern string) ([]string, error) {
 
 // GenerateTemplate generates given src template to out file using given manifest
 func GenerateTemplate(wixFile *manifest.WixManifest, src string, out string) error {
-	tpl, err := template.ParseFiles(src)
+	tpl, err := template.New("").Funcs(funcMap).ParseFiles(src)
 	if err != nil {
 		return err
 	}
@@ -27,7 +33,7 @@ func GenerateTemplate(wixFile *manifest.WixManifest, src string, out string) err
 		return err
 	}
 	defer fileWriter.Close()
-	err = tpl.Execute(fileWriter, wixFile)
+	err = tpl.ExecuteTemplate(fileWriter, filepath.Base(src), wixFile)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #2 

This PR allows users to add (un)install hooks like the following in their `wix.json` file:

```json
  "hooks": [
      {"command": "sc.exe create ServiceName binPath=\"[INSTALLDIR]myexec.exe\" type=share start=auto DisplayName=\"Service Description\"", "when": "install"},
      {"command": "sc.exe start ServiceName", "when": "install"},
      {"command": "sc.exe stop ServiceName", "when": "uninstall"},
      {"command": "sc.exe delete ServiceName", "when": "uninstall"}
  ]
```

(which, BTW, is a workaround for #9 until services are supported directly)

~It doesn't (yet) provide any magic for executing batch files directly (i.e. the user needs to invoke `cmd.exe`) but it should be easy to extend the code creating `CookedCommand`.~