### PR TITLE
Add a new command to add/update the list of files in a wix manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ I guess most of your changes will be about the `WixUI_HK.wxs` file.
 # Cli
 
 ###### $ go-msi -h
-```sh
+```
 NAME:
    go-msi - Easy msi pakage for Go
 
@@ -155,7 +155,7 @@ GLOBAL OPTIONS:
 ```
 
 ###### $ go-msi check-env -h
-```sh
+```
 NAME:
    go-msi check-env - Provide a report about your environment setup
 
@@ -164,7 +164,7 @@ USAGE:
 ```
 
 ###### $ go-msi check-json -h
-```sh
+```
 NAME:
    go-msi check-json - Check the JSON wix manifest
 
@@ -176,7 +176,7 @@ OPTIONS:
 ```
 
 ###### $ go-msi set-guid -h
-```sh
+```
 NAME:
    go-msi set-guid - Sets appropriate guids in your wix manifest
 
@@ -189,7 +189,7 @@ OPTIONS:
 ```
 
 ###### $ go-msi make -h
-```sh
+```
 NAME:
    go-msi make - All-in-one command to make MSI files
 
@@ -208,7 +208,7 @@ OPTIONS:
 ```
 
 ###### $ go-msi choco -h
-```sh
+```
 NAME:
    go-msi choco - Generate a chocolatey package of your msi files
 
@@ -226,7 +226,7 @@ OPTIONS:
 ```
 
 ###### $ go-msi generate-templates -h
-```sh
+```
 NAME:
    go-msi generate-templates - Generate wix templates
 
@@ -242,7 +242,7 @@ OPTIONS:
 ```
 
 ###### $ go-msi to-windows -h
-```sh
+```
 NAME:
    go-msi to-windows - Write Windows1252 encoded file
 
@@ -255,7 +255,7 @@ OPTIONS:
 ```
 
 ###### $ go-msi to-rtf -h
-```sh
+```
 NAME:
    go-msi to-rtf - Write RTF formatted file
 
@@ -269,7 +269,7 @@ OPTIONS:
 ```
 
 ###### $ go-msi gen-wix-cmd -h
-```sh
+```
 NAME:
    go-msi gen-wix-cmd - Generate a batch file of Wix commands to run
 
@@ -285,7 +285,7 @@ OPTIONS:
 ```
 
 ###### $ go-msi run-wix-cmd -h
-```sh
+```
 NAME:
    go-msi run-wix-cmd - Run the batch file of Wix commands
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ VERSION:
 COMMANDS:
      check-json          Check the JSON wix manifest
      check-env           Provide a report about your environment setup
+     set-files           Adds or removes files from your wix manifest
      set-guid            Sets appropriate guids in your wix manifest
      generate-templates  Generate wix templates
      to-windows          Write Windows1252 encoded file
@@ -173,6 +174,21 @@ USAGE:
 
 OPTIONS:
    --path value, -p value  Path to the wix manifest file (default: "wix.json")
+```
+
+###### $ go-msi set-files -h
+```
+NAME:
+   go-msi.exe set-files - Adds or removes files from your wix manifest
+
+USAGE:
+   go-msi.exe set-files [command options] [arguments...]
+
+OPTIONS:
+   --path value, -p value      Path to the wix manifest file (default: "wix.json")
+   --includes value, -i value  Files to include, use of * is permitted
+   --excludes value, -e value  Files to exclude, use of * is permitted
+   --test, -t                  Test mode, does not modify the wix manifest file but exits with an error instead
 ```
 
 ###### $ go-msi set-guid -h

--- a/main.go
+++ b/main.go
@@ -307,7 +307,13 @@ func main() {
 		},
 	}
 
-	app.Run(os.Args)
+	if err := app.Run(os.Args); err != nil {
+		fmt.Println(err)
+		if e, ok := err.(*cli.ExitError); ok {
+			os.Exit(e.ExitCode())
+		}
+		os.Exit(1)
+	}
 }
 
 var verReg = regexp.MustCompile(`\s[0-9]+[.][0-9]+[.][0-9]+`)

--- a/main.go
+++ b/main.go
@@ -65,6 +65,30 @@ func main() {
 			Action: checkEnv,
 		},
 		{
+			Name:   "set-files",
+			Usage:  "Adds or removes files from your wix manifest",
+			Action: setFiles,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "path, p",
+					Value: "wix.json",
+					Usage: "Path to the wix manifest file",
+				},
+				cli.StringSliceFlag{
+					Name:  "includes, i",
+					Usage: "Files to include, use of * is permitted",
+				},
+				cli.StringSliceFlag{
+					Name:  "excludes, e",
+					Usage: "Files to exclude, use of * is permitted",
+				},
+				cli.BoolFlag{
+					Name:  "test, t",
+					Usage: "Test mode, does not modify the wix manifest file but exits with an error instead",
+				},
+			},
+		},
+		{
 			Name:   "set-guid",
 			Usage:  "Sets appropriate guids in your wix manifest",
 			Action: setGUID,
@@ -359,6 +383,111 @@ func checkJSON(c *cli.Context) error {
 		fmt.Println("To update your file automatically run:")
 		fmt.Println("     go-msi set-guid")
 		return cli.NewExitError("Incomplete manifest file detected", 1)
+	}
+	return nil
+}
+
+func setFiles(c *cli.Context) error {
+	path := c.String("path")
+	includes := c.StringSlice("includes")
+	excludes := c.StringSlice("excludes")
+	test := c.Bool("test")
+
+	if len(includes) == 0 {
+		return cli.NewExitError(fmt.Errorf("--includes argument is required"), 1)
+	}
+	wixFile := manifest.WixManifest{}
+	err := wixFile.Load(path)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+
+	failed := false
+	dir := filepath.Dir(path)
+	out := make(map[string]bool)
+	err = glob(dir, excludes, func(match string) {
+		out[match] = true
+	})
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+	in := make(map[string]bool)
+	err = glob(dir, includes, func(match string) {
+		if !out[match] {
+			in[match] = true
+			if !isIn(match, wixFile.Files.Items) {
+				fmt.Printf("    adding %q\n", match)
+				failed = true
+				if !test {
+					wixFile.Files.Items = append(wixFile.Files.Items, match)
+				}
+			}
+		}
+	})
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	for i := len(wixFile.Files.Items) - 1; i >= 0; i-- {
+		file := wixFile.Files.Items[i]
+		if !in[file] {
+			fmt.Printf("    removing %q\n", file)
+			failed = true
+			if !test {
+				wixFile.Files.Items = append(wixFile.Files.Items[:i], wixFile.Files.Items[i+1:]...)
+			}
+		}
+
+	}
+
+	if !failed {
+		return nil
+	}
+	if test {
+		return fmt.Errorf("file list not up to date")
+	}
+	err = wixFile.Write(path)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	fmt.Println("The file is saved on disk")
+	return nil
+}
+
+func isIn(s string, sl []string) bool {
+	for _, e := range sl {
+		if e == s {
+			return true
+		}
+	}
+	return false
+}
+
+func glob(dir string, files []string, f func(match string)) error {
+	for _, file := range files {
+		matches, err := filepath.Glob(filepath.Join(dir, file))
+		if err != nil {
+			return err
+		}
+		if matches == nil {
+			return fmt.Errorf("file %q does not exist", file)
+		}
+		for _, match := range matches {
+			info, err := os.Stat(match)
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				continue
+			}
+			if dir != "" {
+				match, err = filepath.Rel(dir, match)
+				if err != nil {
+					return err
+				}
+			}
+			f(filepath.ToSlash(match))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This PR adds a new command which helps with handling projects with many files and/or files being added/removed.
The new command works like this:
```
$ go-msi set-files -h
NAME:
   go-msi.exe set-files - Adds or removes files matching the given include and exclude filters

USAGE:
   go-msi.exe set-files [command options] [arguments...]

OPTIONS:
   --path value, -p value      Path to the wix manifest file (default: "wix.json")
   --includes value, -i value  Files to include, use of * is permitted
   --excludes value, -e value  Files to exclude, use of * is permitted
   --test, -t                  Test mode, does not modify the wix manifest file but exits with an error instead
```
and can be invoked as
```
$ go-msi set-files --includes build/d4w/artifacts/*
```
It will scan the path provided as include/exclude filters to construct the list of files to be included in the wix manifest and then compare it with the actual files in the manifest.
It will report missing and extra file entries and update them accordingly (unless the `--test` flag is passed).

This is a first draft, I can polish it a bit (for instance I'm not sure whether the file scanning should not be recursive?) and add tests if this sparks interest…
I can also move the 2 small commits into a separate PR if needed.